### PR TITLE
metrics: MetricsReporter started

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ all the incoming requests.
 ## Installation and usage
 
 ```
-$ go get github.com/GoogleCloudPlatform/stackdriver-reverse-proxy
+$ go get github.com/GoogleCloudPlatform/stackdriver-reverse-proxy/cmd/stackdriver-reverse-proxy
 ```
 
 Once installed, start the proxy server and target your application server. For example, if

--- a/cmd/stackdriver-reverse-proxy/main.go
+++ b/cmd/stackdriver-reverse-proxy/main.go
@@ -26,9 +26,12 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/trace"
+
+	sproxy "github.com/GoogleCloudPlatform/stackdriver-reverse-proxy"
 )
 
 var (
@@ -39,6 +42,11 @@ var (
 	tlsCert   string
 	tlsKey    string
 	traceFrac float64
+
+	monitorHTTPOff bool
+	monitorPeriod  string
+
+	enableErrorReports bool
 )
 
 const usage = `stackdriver-reverse-proxy [opts...] -target=<host:port>
@@ -52,7 +60,9 @@ Options:
   -project        Google Cloud Platform project ID if running outside of GCP.
 
 Tracing options:
-  -trace-fraction Tracing sampling fraction, between 0 and 1.0.
+  -trace-fraction    Tracing sampling fraction, between 0 and 1.0.
+  -monitor-http-off  Turning on reporting HTTP stats to StackDriver Monitoring
+  -monitor-period    The period at which StackDriver Monitoring reports are sent
 
 HTTPS options:
   -tls-cert TLS cert file to start an HTTPS proxy.
@@ -71,6 +81,8 @@ func main() {
 	flag.Float64Var(&traceFrac, "trace-fraction", 1, "sampling fraction for tracing")
 	flag.StringVar(&tlsCert, "tls-cert", "", "TLS cert file to start an HTTPS proxy")
 	flag.StringVar(&tlsKey, "tls-key", "", "TLS key file to start an HTTPS proxy")
+	flag.BoolVar(&monitorHTTPOff, "monitor-http-off", false, "send monitor reports to stackdriver Monitoring")
+	flag.StringVar(&monitorPeriod, "monitor-period", "1m", "the period for stackdriver Monitoring")
 	flag.Parse()
 
 	if target == "" {
@@ -95,6 +107,24 @@ func main() {
 		log.Fatalf("Cannot URL parse -target: %v", err)
 	}
 
+	var metricsReporter *sproxy.MetricsReporter
+	if !monitorHTTPOff {
+		period, err := time.ParseDuration(monitorPeriod)
+		if err != nil {
+			period = 1 * time.Minute
+		}
+		metricsReporter, err = sproxy.NewMetricsReporter(period)
+		if err != nil {
+			log.Fatalf("Cannot create the metricsReporter: %v", err)
+		}
+		metricsReporter.SetStatsReceiver(sendToStackDriverMonitoring)
+
+		// Fire up the metricsReporter
+		go metricsReporter.Do()
+		// Close it once we are done
+		defer metricsReporter.Close()
+	}
+
 	tc, err := trace.NewClient(ctx, projectID)
 	if err != nil {
 		log.Fatalf("Cannot initiate trace client: %v", err)
@@ -104,7 +134,8 @@ func main() {
 
 	proxy := httputil.NewSingleHostReverseProxy(url)
 	proxy.Transport = &transport{
-		Trace: tc,
+		Trace:           tc,
+		MetricsReporter: metricsReporter,
 	}
 	if tlsCert != "" && tlsKey != "" {
 		log.Fatal(http.ListenAndServeTLS(listen, tlsCert, tlsKey, proxy))
@@ -114,15 +145,47 @@ func main() {
 }
 
 type transport struct {
-	Trace *trace.Client
+	Trace           *trace.Client
+	MetricsReporter *sproxy.MetricsReporter
 }
 
-func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	s := t.Trace.SpanFromRequest(req)
 	defer s.Finish()
 
 	req.Header.Set("X-Cloud-Trace-Context", s.Header())
-	resp, err := http.DefaultTransport.RoundTrip(req)
+
+	if mr := t.MetricsReporter; mr != nil {
+		startTime := time.Now()
+		traceID := s.TraceID()
+		go mr.AddEvent(&sproxy.Event{
+			Request:   true,
+			TraceID:   traceID,
+			StartTime: startTime,
+			EndTime:   startTime,
+		})
+
+		// At the end, once we have a response,
+		// capture its end metrics and fire off events
+		defer func() {
+			statusCode := 500
+			if resp != nil {
+				statusCode = resp.StatusCode
+			}
+
+			// Fire off in a goroutine so that RoundTrip isn't blocked
+			// at all
+			go mr.AddEvent(&sproxy.Event{
+				StartTime:  startTime,
+				EndTime:    time.Now(),
+				TraceID:    traceID,
+				StatusCode: statusCode,
+				Err:        err,
+			})
+		}()
+	}
+
+	resp, err = http.DefaultTransport.RoundTrip(req)
 	if err != nil {
 		s.SetLabel("error", err.Error())
 	}
@@ -132,4 +195,10 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 func usageExit() {
 	flag.Usage()
 	os.Exit(1)
+}
+
+func sendToStackDriverMonitoring(stats *sproxy.InflightStats) error {
+	// TODO (@odeke-em, @rakyll):
+	// Insert the code for uploading to StackDriverMonitoring here
+	return nil
 }

--- a/sproxy.go
+++ b/sproxy.go
@@ -1,0 +1,185 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sproxy
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type Event struct {
+	StatusCode   int
+	Request      bool
+	ResponseSize int64
+	StartTime    time.Time
+	EndTime      time.Time
+	TraceID      string
+	Err          error
+}
+
+type MetricsReporter struct {
+	currentEvents []*Event
+	period        time.Duration
+
+	cancelChan <-chan bool
+	cancelFn   func() error
+
+	// mu protects statsRecvFn
+	mu          sync.RWMutex
+	statsRecvFn func(*InflightStats) error
+}
+
+const defaultPeriod = 1 * time.Minute
+
+func NewMetricsReporter(period time.Duration) (*MetricsReporter, error) {
+	if period <= 0 {
+		period = defaultPeriod
+	}
+	cancelChan, cancelFn := makeCanceler()
+	mr := &MetricsReporter{
+		period:        period,
+		currentEvents: make([]*Event, 0, 512), // Arbitrary value
+		cancelChan:    cancelChan,
+		cancelFn:      cancelFn,
+	}
+	return mr, nil
+}
+
+func (mr *MetricsReporter) Close() error {
+	if mr.cancelFn == nil {
+		return nil
+	}
+	return mr.cancelFn()
+}
+
+func (mr *MetricsReporter) AddEvent(evt *Event) {
+	mr.mu.Lock()
+	mr.currentEvents = append(mr.currentEvents, evt)
+	mr.mu.Unlock()
+}
+
+var errAlreadyClosed = errors.New("already closed")
+
+func makeCanceler() (<-chan bool, func() error) {
+	cancelChan := make(chan bool, 1)
+	var cancelOnce sync.Once
+	cancelFn := func() error {
+		var err error = errAlreadyClosed
+		cancelOnce.Do(func() {
+			close(cancelChan)
+			err = nil
+		})
+		return err
+	}
+
+	return cancelChan, cancelFn
+}
+
+// Do is a synchronous method that reports events
+// at the end of every specified sampling period
+// sending them to the StackDriver Monitoring API.
+func (mr *MetricsReporter) Do() {
+	i := uint64(0)
+	for {
+		select {
+		case <-mr.cancelChan:
+			return
+		case <-time.After(mr.period):
+			// Otherwise the duration has lapsed
+		}
+
+		i += 1
+		drainedEvents := mr.drainEvents()
+
+		go mr.reportEvents(drainedEvents, i)
+	}
+}
+
+// drainEvents is a concurrent-safe method that
+// creates a frozen copy of mr.currentEvents and
+// then drains mr.currentEvents resetting it an empty slice.
+func (mr *MetricsReporter) drainEvents() []*Event {
+	mr.mu.Lock()
+	drained := make([]*Event, len(mr.currentEvents))
+	copy(drained, mr.currentEvents)
+	mr.currentEvents = mr.currentEvents[:0]
+	mr.mu.Unlock()
+	return drained
+}
+
+func (mr *MetricsReporter) reportEvents(events []*Event, nIter uint64) {
+	nResponses := 0
+	nRequests := 0
+	totalResponseDuration := time.Duration(0)
+	responsesCounter := make(map[int]int)
+	traceIDs := make([]string, 0, len(events))
+	for _, evt := range events {
+		traceIDs = append(traceIDs, evt.TraceID)
+		switch evt.Request {
+		case true:
+			nRequests += 1
+		default:
+			statusIndex := evt.StatusCode / 100
+			responsesCounter[statusIndex] += 1
+			nResponses += 1
+			totalResponseDuration += evt.EndTime.Sub(evt.StartTime)
+		}
+	}
+
+	if nResponses <= 0 {
+		nResponses = 1
+	}
+
+	// Calculate the average rate of different
+	// XXX responses within the past duration.
+	rateXXXResponsesMap := make(map[int]float64)
+	for statusIndex, count := range responsesCounter {
+		rateXXXResponsesMap[statusIndex] = 100.0 * (float64(count) / float64(nResponses))
+	}
+
+	stats := &InflightStats{
+		NRequests:                      nRequests,
+		TraceIDs:                       traceIDs,
+		NthIteration:                   nIter,
+		RateResponseStats:              rateXXXResponsesMap,
+		AverageResponseDurationSeconds: float64(totalResponseDuration.Seconds()) / float64(nResponses),
+	}
+	mr.sendStats(stats)
+}
+
+type InflightStats struct {
+	NRequests                      int
+	TraceIDs                       []string
+	NthIteration                   uint64
+	RateResponseStats              map[int]float64
+	AverageResponseDurationSeconds float64
+}
+
+func (mr *MetricsReporter) sendStats(stats *InflightStats) error {
+	mr.mu.RLock()
+	recvFn := mr.statsRecvFn
+	mr.mu.RUnlock()
+	if recvFn == nil {
+		return nil
+	}
+	return recvFn(stats)
+}
+
+func (mr *MetricsReporter) SetStatsReceiver(statsRecvFn func(*InflightStats) error) {
+	mr.mu.Lock()
+	mr.statsRecvFn = statsRecvFn
+	mr.mu.Unlock()
+}

--- a/sproxy_test.go
+++ b/sproxy_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sproxy_test
+
+import (
+	"encoding/json"
+	"log"
+	"math/rand"
+	"testing"
+	"time"
+
+	sproxy "github.com/GoogleCloudPlatform/stackdriver-reverse-proxy"
+)
+
+func TestReporting(t *testing.T) {
+	t.Skipf("This test is very long. Meant to be a usage simulation")
+	mr, err := sproxy.NewMetricsReporter(250 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("metricsReporter: %v", err)
+	}
+	mr.SetStatsReceiver(func(stats *sproxy.InflightStats) error {
+		blob, _ := json.MarshalIndent(stats, "", "  ")
+		log.Printf("statsIn: %s", blob)
+		return nil
+	})
+	go mr.Do()
+	defer mr.Close()
+
+	n := 10000
+	doneChan := make(chan bool, n)
+	for i := 0; i < n; i++ {
+		go func(ii int) {
+			defer func() {
+				doneChan <- true
+			}()
+			startTime := time.Now()
+			evt := &sproxy.Event{
+				StartTime:  startTime,
+				StatusCode: rand.Intn(600) + 100,
+			}
+
+			evt.Request = rand.Intn(37)%2 == 0
+			evt.EndTime = time.Now()
+			mr.AddEvent(evt)
+		}(i)
+
+		refreshTime := time.Duration((1 + rand.Intn(110))) * time.Millisecond
+		<-time.After(refreshTime)
+	}
+
+	for i := 0; i < n; i++ {
+		<-doneChan
+	}
+}


### PR DESCRIPTION
Fixes #5

WIP to report metrics to StackDriver monitoring
about the inflight HTTP requests.

The main abstraction is MetricsReporter with methods
- NewMetricsReporter(period time.Duration)
- SetStatsReceiver(func(stats *sproxy.InflightStats) error
- AddEvent(sproxy.Event)
- go Do()
- Close()

which should be able to initiate a metrics reporter
that receives HTTP event information, aggregates information
periodically and can be stopped at will with .Close()

Here is a sample to show how it works with a simulation:
```go
package main

import (
	"encoding/json"
	"log"
	"math/rand"
	"time"

	sproxy "github.com/GoogleCloudPlatform/stackdriver-reverse-proxy"
)

func main() {
	mr, err := sproxy.NewMetricsReporter(650*time.Millisecond)
	if err != nil {
		log.Fatalf("metricsReporter: %v", err)
	}
	mr.SetStatsReceiver(func(stats *sproxy.InflightStats) error {
		blob, _ := json.MarshalIndent(stats, "", "  ")
		log.Printf("statsIn: %s", blob)
		return nil
	})
	go mr.Do()
	defer mr.Close()

	n := 100000
	doneChan := make(chan bool, n)
	for i := 0; i < n; i++ {
		go func(ii int) {
			defer func() {
				doneChan <- true
			}()
			startTime := time.Now()
			evt := &sproxy.Event{
				StartTime:  startTime,
				StatusCode: rand.Intn(600) + 100,
			}

			evt.Request = rand.Intn(37)%2 == 0
			evt.EndTime = time.Now()
			mr.AddEvent(evt)
		}(i)

		refreshTime := time.Duration((1 + rand.Intn(500))) * time.Millisecond
		<-time.After(refreshTime)
	}

	for i := 0; i < n; i++ {
		<-doneChan
	}
}
```

What is left is just doing the raw StackDriver monitoring client
initialization and organizing the metrics from sproxy.InflightStats
and sending them along.