### PR TITLE
README: always use go get -u

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ all the incoming requests.
 ## Installation and usage
 
 ```
-$ go get github.com/GoogleCloudPlatform/stackdriver-reverse-proxy/cmd/stackdriver-reverse-proxy
+$ go get -u github.com/GoogleCloudPlatform/stackdriver-reverse-proxy/cmd/stackdriver-reverse-proxy
 ```
 
 Once installed, start the proxy server and target your application server. For example, if


### PR DESCRIPTION
It is prefarable for newcomers who haven't discovered the -u flag
yet. If they are going through the installation steps, they're
likely to be looking for the latest version.